### PR TITLE
Revert component and platform order for new structure files

### DIFF
--- a/labels/util/parse_path.js
+++ b/labels/util/parse_path.js
@@ -136,6 +136,10 @@ module.exports = function(path) {
   } else if (!entityComponent.includes(result.component) && 
       !entityComponent.includes(parts[0].replace('.py', ''))) {
     result.type = 'component';
+  } else if (entityComponent.includes(parts[0].replace('.py', ''))) {
+    result.type = 'platform';
+    result.platform = result.component;
+    result.component = parts[0].replace('.py', '');
   } else {
     result.type = 'platform';
     result.platform = parts[0].replace('.py', '');

--- a/test/plugins/componentAndPlatform.spec.js
+++ b/test/plugins/componentAndPlatform.spec.js
@@ -23,7 +23,7 @@ describe('componentAndPlatform', () => {
   });
 
   it('component dir plaform file', () => {
-    assert.deepEqual(getOutput('zwave/light.py'), 'platform: zwave.light');
+    assert.deepEqual(getOutput('zwave/light.py'), 'platform: light.zwave');
   });
 
   it('platform file', () => {

--- a/test/plugins/markCore.spec.js
+++ b/test/plugins/markCore.spec.js
@@ -19,7 +19,7 @@ describe('markCore', () => {
   });
 
   it('core component plaftform file', () => {
-    assert.deepEqual(getOutput('mqtt/fan.py'), 'core');
+    assert.deepEqual(getOutput('mqtt/fan.py'), null);
   });
 
   it('non-core component init', () => {

--- a/test/util/parse_path.spec.js
+++ b/test/util/parse_path.spec.js
@@ -114,8 +114,8 @@ describe('parsePath', () => {
   it('detect new component platform structure', () => {
     result = parsePath('homeassistant/components/hue/light.py');
     assert.equal(result.core, false);
-    assert.equal(result.component, 'hue');
-    assert.equal(result.platform, 'light');
+    assert.equal(result.component, 'light');
+    assert.equal(result.platform, 'hue');
     assert.equal(result.type, 'platform');
   });
 });


### PR DESCRIPTION
hue/light.py => `platform: light.hue`

Keep the platform label backward compatible