### PR TITLE
Don't add platform labels

### DIFF
--- a/labels/util/parse_path.js
+++ b/labels/util/parse_path.js
@@ -1,4 +1,3 @@
-// Components that have multiple files that are not integrations
 var entityComponent = [
   'air_quality',
   'alarm_control_panel',
@@ -128,25 +127,11 @@ module.exports = function(path) {
   }
 
   result.component = parts.shift();
-
-  if (parts[0] === 'services.yaml') {
-    result.type = 'services'
-  } else if (parts[0] == '__init__.py') {
-    result.type = 'component';
-  } else if (!entityComponent.includes(result.component) && 
-      !entityComponent.includes(parts[0].replace('.py', ''))) {
-    result.type = 'component';
-  } else {
-    result.type = 'platform';
-    result.platform = parts[0].replace('.py', '');
-  }
+  result.type = parts[0] === 'services.yaml' ? 'services' : 'component';
 
   if (coreComponents.includes(result.component)) {
     if (result.type !== 'platform' && result.type !== 'services'
         || !entityComponent.includes(result.component)) {
-      result.core = true;
-    } else if (result.type === 'platform'
-        && coreComponentPlatforms.includes(result.component)) {
       result.core = true;
     }
   }

--- a/test/plugins/componentAndPlatform.spec.js
+++ b/test/plugins/componentAndPlatform.spec.js
@@ -23,15 +23,15 @@ describe('componentAndPlatform', () => {
   });
 
   it('component dir plaform file', () => {
-    assert.deepEqual(getOutput('zwave/light.py'), 'platform: zwave.light');
+    assert.deepEqual(getOutput('zwave/light.py'), 'component: zwave');
   });
 
   it('platform file', () => {
-    assert.deepEqual(getOutput('light/hue.py'), 'platform: light.hue');
+    assert.deepEqual(getOutput('hue/light.py'), 'component: hue');
   });
 
   it('platform dir', () => {
-    assert.deepEqual(getOutput('light/lifx/const.py'), 'platform: light.lifx');
+    assert.deepEqual(getOutput('lifx/light/const.py'), 'component: lifx');
   });
 
   it('component services', () => {

--- a/test/plugins/markCore.spec.js
+++ b/test/plugins/markCore.spec.js
@@ -30,17 +30,12 @@ describe('markCore', () => {
     assert.deepEqual(getOutput('hue/config.py'), null);
   });
 
-  it('non-core component plaftform file', () => {
+  it('non-core component platform file', () => {
     assert.deepEqual(getOutput('hue/light.py'), null);
   });
 
   it('entity component', () => {
     assert.deepEqual(getOutput('light/__init__.py'), 'core');
-  });
-
-  it('entity component platform file, legacy', () => {
-    // TODO: need to change after all (or most) platforms move to components
-    assert.deepEqual(getOutput('light/hue.py'), null);
   });
 
   it('coer entity component', () => {

--- a/test/process.spec.js
+++ b/test/process.spec.js
@@ -6,7 +6,7 @@ describe('process', () => {
   it('should work', () => {
 
     filenames = [
-      'homeassistant/components/light/hue.py',
+      'homeassistant/components/hue/light.py',
       'homeassistant/components/services.yaml',
       'homeassistant/components/mqtt/server.py',
       'homeassistant/const.py',
@@ -24,10 +24,10 @@ describe('process', () => {
     }, null, files);
     result.sort();
     assert.deepEqual(result, [
+      'component: hue',
       'component: mqtt',
       'core',
       'merging-to-master',
-      'platform: light.hue'
     ]);
   });
 });

--- a/test/util/parse_path.spec.js
+++ b/test/util/parse_path.spec.js
@@ -67,16 +67,16 @@ describe('parsePath', () => {
     result = parsePath('homeassistant/components/automation/state.py');
     assert.equal(result.core, true);
     assert.equal(result.component, 'automation');
-    assert.equal(result.platform, 'state');
-    assert.equal(result.type, 'platform');
+    assert.equal(result.platform, null);
+    assert.equal(result.type, 'component');
   });
 
-  it('detect platform', () => {
-    result = parsePath('homeassistant/components/light/hue.py');
+  it('detect embedded platform', () => {
+    result = parsePath('homeassistant/components/hue/light.py');
     assert.equal(result.core, false);
-    assert.equal(result.component, 'light');
-    assert.equal(result.platform, 'hue');
-    assert.equal(result.type, 'platform');
+    assert.equal(result.component, 'hue');
+    assert.equal(result.platform, null);
+    assert.equal(result.type, 'component');
   });
 
   it('mark core services', () => {
@@ -115,7 +115,7 @@ describe('parsePath', () => {
     result = parsePath('homeassistant/components/hue/light.py');
     assert.equal(result.core, false);
     assert.equal(result.component, 'hue');
-    assert.equal(result.platform, 'light');
-    assert.equal(result.type, 'platform');
+    assert.equal(result.platform, null);
+    assert.equal(result.type, 'component');
   });
 });


### PR DESCRIPTION
Removes platform labels, everything will become `component: X`. 

This is step 1. I want to make this `integration: X`, but we will need to run a script against our repo to rename our component labels from `component: hue` to `integration: hue` and merge all platform labels into it.